### PR TITLE
Added about us-header_footer.html and made other changes

### DIFF
--- a/about us-header_footer.html
+++ b/about us-header_footer.html
@@ -20,19 +20,19 @@
         </button>
       	<div class="collapse navbar-collapse" id="navcol-1">
             <ul class="nav navbar-nav ml-auto back">
-                <li class="nav-item mr-6" role="presentation">
+                <li class="nav-item mr-6 sart" role="presentation">
                     <a class="nav-link" href="index.html">Home</a>
                 </li>
-                <li class="nav-item mr-6" role="presentation">
+                <li class="nav-item mr-6 sart" role="presentation">
                     <a class="nav-link" href="expense_report.html">Spending</a>
                 </li>
-                <li class="nav-item mr-6" role="presentation">
+                <li class="nav-item mr-6 sart" role="presentation">
                     <a class="nav-link active" href="ministry_list.html">Ministries</a>
                 </li>
-                <li class="nav-item mr-6" role="presentation">
+                <li class="nav-item mr-6 sart" role="presentation">
                     <a class="nav-link" href="contracts_awarded.html">Contractors</a>
                 </li>
-                <li class="nav-item mr-6" role="presentation">
+                <li class="nav-item mr-6 sart" role="presentation">
                     <a class="nav-link" href="contracts_awarded.html">About us</a>
                 </li>
                 <a class="nav-link" href=""><i class="fa fa-search inp"></i></a>

--- a/about us-header_footer.html
+++ b/about us-header_footer.html
@@ -7,7 +7,7 @@
 <meta name="Description" content="Enter your description here"/>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.0/css/bootstrap.min.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.1/css/all.min.css">
-<link rel="stylesheet" href="assets/css/header_footer.css">
+<link rel="stylesheet" href="assets/css/about us-header_footer.css">
 <title>Federal Government Expense header - Footer</title>
 </head>
 <body>
@@ -19,18 +19,21 @@
             <span><i class="fa fa-bars" aria-hidden="true"></i></span>
         </button>
       	<div class="collapse navbar-collapse" id="navcol-1">
-            <ul class="nav navbar-nav ml-auto">
-                <li class="nav-item mr-3" role="presentation">
+            <ul class="nav navbar-nav ml-auto back">
+                <li class="nav-item mr-6" role="presentation">
                     <a class="nav-link" href="index.html">Home</a>
                 </li>
-                <li class="nav-item mr-3" role="presentation">
+                <li class="nav-item mr-6" role="presentation">
                     <a class="nav-link" href="expense_report.html">Spending</a>
                 </li>
-                <li class="nav-item mr-3" role="presentation">
+                <li class="nav-item mr-6" role="presentation">
                     <a class="nav-link active" href="ministry_list.html">Ministries</a>
                 </li>
-                <li class="nav-item mr-3" role="presentation">
+                <li class="nav-item mr-6" role="presentation">
                     <a class="nav-link" href="contracts_awarded.html">Contractors</a>
+                </li>
+                <li class="nav-item mr-6" role="presentation">
+                    <a class="nav-link" href="contracts_awarded.html">About us</a>
                 </li>
                 <a class="nav-link" href=""><i class="fa fa-search inp"></i></a>
             </ul>

--- a/assets/css/about us-header_footer.css
+++ b/assets/css/about us-header_footer.css
@@ -1,6 +1,9 @@
 .back{ 
 	margin-right: -20px;
 }
+.sart{
+	margin-right: px;
+}
 .nav-link{
 	color: black !important;
 }

--- a/assets/css/about us-header_footer.css
+++ b/assets/css/about us-header_footer.css
@@ -1,0 +1,37 @@
+.back{ 
+	margin-right: -20px;
+}
+.nav-link{
+	color: black !important;
+}
+.nav-link:hover{
+	color: grey !important;
+}
+.my-footer ul {
+  list-style-type: none;
+  padding-left: 0;
+  color: white;
+}.my-footer a {
+  color: #fff !important;
+}
+.my-footer {
+  background-color: #323E48 !important;
+}
+h6{
+	color: white;
+	margin-top: 25px;
+}
+.fa-search{
+	color: grey !important;
+}
+.fa-search:hover{
+	color: black !important;
+}
+.ft{
+	margin-top: 25px;
+}
+.lower{
+	background-color: #1F2430;
+	padding: 10px;
+	background: 
+}


### PR DESCRIPTION
Codes with about us section in the header should use the newly created html and attach its corresponding css. Others without should use the normal header_footer.html with its corresponding css
![image](https://user-images.githubusercontent.com/66222569/86175624-96660180-bb1b-11ea-8b01-0f1bb8043ec0.png)
![image](https://user-images.githubusercontent.com/66222569/86175668-ab429500-bb1b-11ea-9e0c-3e3e2a31d0ff.png)
![image](https://user-images.githubusercontent.com/66222569/86175730-c3b2af80-bb1b-11ea-920a-813f554c55f9.png)


